### PR TITLE
Fix for rule_set AddRule() in FBSD12

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -12,7 +12,7 @@ import (
 /*
 int init_pfioc_trans(struct pfioc_trans *tx, int elements) {
 	tx->size = elements;
-	tx->esize = elements * sizeof(struct pfioc_trans_e);
+	tx->esize = sizeof(struct pfioc_trans_e);
 	tx->array = (struct pfioc_trans_e*)calloc(elements,
 		sizeof(struct pfioc_trans_e));
 	if (tx->array == NULL) {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -26,7 +26,7 @@ func TestRuleSetRollback(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = frs.AddRule(&rule)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	err = tx.Rollback()
 	assert.NoError(t, err)


### PR DESCRIPTION
Based on: https://github.com/datawire/pf/commit/141f080118064bc365f7a2040794850bfedb2552

- Set the esize member of the transaction struct to the element size rather than the total size.
 - Make a DIOCBEGINADDRS ioctl before adding a rule.
 - Fix the rollback test to assert that there is *not* an error prior to rolling back.